### PR TITLE
bugfix: Add trailing slash to url to fix timeout exception

### DIFF
--- a/src/SapitiClient.php
+++ b/src/SapitiClient.php
@@ -93,7 +93,7 @@ class SapitiClient
 		$httpMethod = strtoupper($httpMethod);
 		if (!in_array($httpMethod, array('GET', 'POST', 'PATCH', 'DELETE'))) throw new InvalidHTTPMethodException();
 		$server_url = $this->getGeneralApiURL();
-		$full_url = implode('/', array($server_url, ltrim($functionName, '/')));
+		$full_url = implode('/', array($server_url, rtrim(ltrim($functionName, '/'), '/'))).'/';
 
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $full_url);


### PR DESCRIPTION
Since some weeks the client is broken.

```
Fatal error: Uncaught Sapiti\Exceptions\CurlException: CURL error : Operation timed out after 30073 milliseconds with 0 bytes received in ./SapitiClient/src/SapitiClient.php:122
Stack trace:
#0 ./SapitiClient/src/Repositories/System.php(21): Sapiti\SapitiClient->callAPI('ping', 'GET')
#1 ./SapitiClient/index.php(19): Sapiti\Repositories\System->ping()
#2 {main}
  thrown in ./SapitiClient/src/SapitiClient.php on line 122
```

The service now need a trailing slash to the url to work